### PR TITLE
fix: GitHub 프로필 링크를 jjang-jun으로 변경

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -2,7 +2,7 @@
   "author": "jjangjun",
   "title": "어렴풋, 모호한 것 보다는 상세하고 명확하게",
   "links": [
-    { "name": "github", "url": "https://github.com/95rolancia" },
+    { "name": "github", "url": "https://github.com/jjang-jun" },
     { "name": "linkedin", "url": "https://www.linkedin.com/in/junhyeok-jang-167a59240" }
   ]
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@
 
 import { AiFillGithub } from 'react-icons/ai'
 
-const LINKS = [{ icon: <AiFillGithub />, url: 'https://github.com/95rolancia' }]
+const LINKS = [{ icon: <AiFillGithub />, url: 'https://github.com/jjang-jun' }]
 
 export default function Footer() {
   return (


### PR DESCRIPTION
## Summary
- GitHub 프로필 URL을 `95rolancia` → `jjang-jun`으로 변경
- 변경 파일: `data/metadata.json`, `src/components/Footer.tsx`

## Test plan
- [ ] 푸터의 GitHub 아이콘 클릭 시 https://github.com/jjang-jun 으로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)