### PR TITLE
style: Footer UI 개선 및 서버 컴포넌트로 리팩토링

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,29 +1,42 @@
-'use client'
+import { AiFillGithub, AiFillLinkedin } from 'react-icons/ai'
+import { getAuthor, getLinks } from '@/lib/metadata'
+import { IconType } from 'react-icons'
 
-import { AiFillGithub } from 'react-icons/ai'
+const ICON_MAP: Record<string, IconType> = {
+  github: AiFillGithub,
+  linkedin: AiFillLinkedin,
+}
 
-const LINKS = [{ icon: <AiFillGithub />, url: 'https://github.com/jjang-jun' }]
+export default async function Footer() {
+  const [author, links] = await Promise.all([getAuthor(), getLinks()])
 
-export default function Footer() {
   return (
-    <footer className="mx-auto max-w-2xl flex flex-col items-center my-2 px-6 md:px-8">
-      <ul className="flex gap-4 mb-2">
-        {LINKS.map((link, index) => (
-          <a
-            key={index}
-            href={link.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-3xl hover:text-primary-500"
-          >
-            {link.icon}
-          </a>
-        ))}
-      </ul>
-
-      <p className="text-sm text-center">
-        {`\u00A92023-${new Date().getFullYear()} jjangjun All Rights Reserved.`}
-      </p>
+    <footer className="mx-auto max-w-2xl px-6 md:px-8">
+      <div className="border-t border-gray-200 py-6 flex flex-col items-center gap-3">
+        <nav aria-label="소셜 링크">
+          <ul className="flex gap-4">
+            {links.map((link) => {
+              const Icon = ICON_MAP[link.name]
+              return (
+                <li key={link.name}>
+                  <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={link.name}
+                    className="text-2xl text-gray-600 hover:text-primary-500 transition-colors"
+                  >
+                    {Icon && <Icon />}
+                  </a>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+        <p className="text-sm text-gray-500">
+          {`\u00A92023-${new Date().getFullYear()} ${author} All Rights Reserved.`}
+        </p>
+      </div>
     </footer>
   )
 }


### PR DESCRIPTION
## Summary
- `'use client'` 제거 → async 서버 컴포넌트 전환
- 하드코딩 링크/작성자 → `metadata.json`에서 동적 로딩
- LinkedIn 아이콘 추가 (ICON_MAP 기반 확장 구조)
- 시맨틱 HTML 개선 (`<nav>`, `<ul>/<li>`, `aria-label`)
- 상단 구분선 + 여백 조정으로 시각적 분리

## Test plan
- [ ] 푸터에 GitHub + LinkedIn 아이콘 표시 확인
- [ ] 각 아이콘 클릭 시 올바른 URL로 이동
- [ ] 저작권 텍스트에 작성자 이름 표시
- [ ] 모바일/데스크톱 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)